### PR TITLE
Build config: publish http client lib jars

### DIFF
--- a/.github/workflows/upload-http-client-jars.yml
+++ b/.github/workflows/upload-http-client-jars.yml
@@ -1,0 +1,29 @@
+# Jar files uploaded are used as a maven dependency by server
+name: Create Http JAR files and upload to github packages
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'http-clients/**'
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  build:
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Fetch depth of 0 is needed so we checkout the full revision history
+          # The current revision count will be used as our build-number
+          fetch-depth: '0'
+      - name: set build version variables
+        run: |
+          COMMIT_NUMBER=$(git rev-list --count HEAD)
+          echo "commit_number=$COMMIT_NUMBER" | tee -a $GITHUB_ENV
+      - name: Publish HTTP client JARs (used by servers)
+        run: ./gradlew publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_NUMBER: ${{ env.COMMIT_NUMBER }}

--- a/http-clients/lobby-client/build.gradle
+++ b/http-clients/lobby-client/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("maven-publish")
+}
+
 dependencies {
     implementation "io.github.openfeign:feign-core:$feignCoreVersion"
     implementation project(":game-app:domain-data")
@@ -9,4 +13,25 @@ dependencies {
     testImplementation "ru.lanwen.wiremock:wiremock-junit5:$wireMockJunit5Version"
     testImplementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     testImplementation project(":lib:test-common")
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/triplea-game/triplea"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            groupId = "org.triplea"
+            artifactId = "http.client.lobby"
+            version = "0." + System.getenv("COMMIT_NUMBER")
+            from(components.java)
+        }
+    }
 }


### PR DESCRIPTION
Updates github actions & gradle to publish JAR files of http client libraries. The servers will in turn have a maven dependency on these newly upload JAR files.

<!--
Please add any notes for the reviewers in the section below.
  Things to include:
     - If this PR has multiple commits, summarize what has changed
     - Mention any manual testing done.
     - If there are UI updates, please include before & after screenshots
-->

## Notes to Reviewer
